### PR TITLE
make hasRole accessible to lib consumers

### DIFF
--- a/projects/ng-auth/src/lib/auth.service.ts
+++ b/projects/ng-auth/src/lib/auth.service.ts
@@ -164,7 +164,7 @@ export class AuthService {
     }));
   }
 
-  private hasRole(roleName: string): boolean {
+  public hasRole(roleName: string): boolean {
     const roleClaim = this.getUserProfile()?.role as string;
     if (roleClaim && Array.isArray(roleClaim)) {
       const roles = Array.from(roleClaim);


### PR DESCRIPTION
Only exposing the `isAdmin()` method to consumers is very restristive.
The Case-management BO (consumer of current lib) needs to check different user roles (other than the Admin role).