### PR TITLE
multiple date filters

### DIFF
--- a/projects/ng-components/src/lib/controls/advanced-search/advanced-search.component.ts
+++ b/projects/ng-components/src/lib/controls/advanced-search/advanced-search.component.ts
@@ -88,16 +88,16 @@ export class AdvancedSearchComponent implements OnInit {
     if (this.selectedField.dataType === 'daterange') {
       if (!this.selectedField.multiTerm) {
         this.filters = this.filters.filter((f) => {
-          return f.member !== QueryParameters.FILTER_FROM && f.member !== QueryParameters.FILTER_TO;
+          return f.dataType !== 'datetime';
         });
       }
       if (this.fieldValueDateFrom) {
-        const filterClauseFrom = new FilterClause(QueryParameters.FILTER_FROM, this.fieldValueDateFrom, Operators.GREATER_THAN_EQUAL.value as FilterClause.Op, 'datetime', this.searchOptions);
+        const filterClauseFrom = new FilterClause(this.selectedField.field, this.fieldValueDateFrom, Operators.GREATER_THAN_EQUAL.value as FilterClause.Op, 'datetime', this.searchOptions);
         this.filters.push(filterClauseFrom);
       }
 
       if (this.fieldValueDateTo) {
-        const filterClauseTo = new FilterClause(QueryParameters.FILTER_TO, this.fieldValueDateTo, Operators.LESS_THAN_EQUAL.value as FilterClause.Op, 'datetime', this.searchOptions);
+        const filterClauseTo = new FilterClause(this.selectedField.field, this.fieldValueDateTo, Operators.LESS_THAN_EQUAL.value as FilterClause.Op, 'datetime', this.searchOptions);
         this.filters.push(filterClauseTo);
       }
     }


### PR DESCRIPTION
Problem
When filtering by date range, the FilterClause members are set to hardcoded strings 'from' and 'to' for filterClauseFrom and filterClauseTo respectively. If we wanted to have two or more date filters (e.g. paymentDate, createdDate) it would not be possible to distinct the date member which we want the filters (filterClauseFrom & filterClauseTo) to be applied to.

Suggested Solution
Instead of setting hardcoded strings ('from' & 'to') for the FilterClause member, we set the field name of the selectedField (e.g. paymentDate, createdDate) so that the client can recognize which date filter is currently active. The Operator value can be used to distinguish between 'From' and 'To'.