### PR TITLE
Enhanced Combobox component selector renaming

### DIFF
--- a/projects/app/src/app/components/sample-enhanced-combobox/sample-enhanced-combobox.component.html
+++ b/projects/app/src/app/components/sample-enhanced-combobox/sample-enhanced-combobox.component.html
@@ -2,7 +2,7 @@
 
     <label for="contacts-combobox-advanced"
             class="field-label">Όνομα (*)</label>
-    <app-enhanced-combobox id="contacts-combobox-advanced"
+    <lib-enhanced-combobox id="contacts-combobox-advanced"
                     [items]="contacts"
                     [itemTemplate]="itemTemplate"
                     [selectedItemTemplate]="selectedItemTemplate"
@@ -15,7 +15,7 @@
                     [selectedItemsFilter]="enhancedContactsFilter"
                     [noResultsTemplate]="noResultsTemplate"
                     #advancedContactsCombobox>
-    </app-enhanced-combobox>
+    </lib-enhanced-combobox>
 </div>
 <ng-template #noResultsTemplate
              let-searchTerm>

--- a/projects/app/src/app/components/sample-enhanced-combobox/sample-enhanced-combobox.component.ts
+++ b/projects/app/src/app/components/sample-enhanced-combobox/sample-enhanced-combobox.component.ts
@@ -3,14 +3,14 @@ import { HttpClient } from '@angular/common/http';
 import { lastValueFrom } from 'rxjs';
 import { Contact } from './contact';
 import { ContactResultSet } from '../combobox/contact';
-import { ComboboxComponent } from '../../../../../ng-components/src/public-api';
+import { EnhancedComboboxComponent } from 'projects/ng-components/src/public-api';
 
 @Component({
     selector: 'app-sample-enhanced-combobox',
     templateUrl: './sample-enhanced-combobox.component.html'
 })
 export class SampleEnhancedComboboxComponent implements OnInit {
-    @ViewChild('advancedContactsCombobox', { static: true }) private _advancedContactsCombobox!: ComboboxComponent;
+    @ViewChild('advancedContactsCombobox', { static: true }) private _advancedContactsCombobox!: EnhancedComboboxComponent;
 
     constructor(
         private _changeDetector: ChangeDetectorRef,

--- a/projects/ng-components/src/lib/controls/enhanced-combobox/enhanced-combobox.component.ts
+++ b/projects/ng-components/src/lib/controls/enhanced-combobox/enhanced-combobox.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@an
 import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
 
 @Component({
-    selector: 'app-enhanced-combobox',
+    selector: 'lib-enhanced-combobox',
     templateUrl: './enhanced-combobox.component.html'
 })
 export class EnhancedComboboxComponent implements OnInit {


### PR DESCRIPTION
… in sample

Changed the component selector from `app-enhanced-combobox` to `lib-enhanced-combobox` in both HTML and TypeScript files. Updated the import path for `EnhancedComboboxComponent` and changed the type of `_advancedContactsCombobox` to reflect the new component type. Ensured the HTML template is consistent with the new selector.