### PR TITLE
[ng-auth] User observable is now reactive

### DIFF
--- a/projects/ng-auth/package.json
+++ b/projects/ng-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indice/ng-auth",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Indice extensions for Angular v20 using oidc-client",
   "repository": {
     "type": "git",

--- a/projects/ng-auth/src/lib/auth.service.ts
+++ b/projects/ng-auth/src/lib/auth.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 
 import { IdTokenClaims, SignoutResponse, User, UserManager } from 'oidc-client-ts';
-import { BehaviorSubject, from, Observable, throwError } from 'rxjs';
+import { BehaviorSubject, from, Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { AUTH_SETTINGS } from './tokens';
 import { IAuthSettings, SignInRedirectOptions } from './types';
@@ -12,7 +12,7 @@ import { IAuthSettings, SignInRedirectOptions } from './types';
 })
 export class AuthService {
   private _userManager: UserManager;
-  private _user: User = null as any;
+  private _user: User | null = null;
   private _userSubject: BehaviorSubject<User | null> = new BehaviorSubject<User | null>(null);
   public user$ = this._userSubject.asObservable();
 
@@ -34,6 +34,7 @@ export class AuthService {
     });
 
     this._userManager.events.addUserSignedOut(() => {
+      this.clearUser();
       this._userManager.clearStaleState();
       this._userManager.removeUser();
     });
@@ -85,7 +86,7 @@ export class AuthService {
     return this.getFullName() || this.getEmail() || this.getUserName() || '';
   }
 
-  public getCurrentUser(): User {
+  public getCurrentUser(): User | null {
     return this._user;
   }
 
@@ -116,26 +117,22 @@ export class AuthService {
   }
 
   public removeUser(): Observable<void> {
+    this.clearUser();
     this._userManager.clearStaleState();
     return from(this._userManager.removeUser());
   }
 
   public signoutRedirectCallback(): Observable<SignoutResponse> {
     return from(this._userManager.signoutRedirectCallback()).pipe(map((response: SignoutResponse) => {
-      this._user = null as any;
-      this._userSubject.next(null);
+      this.clearUser();
       return response;
-    }, (error: any) => {
-      throwError(error);
     }));
   }
 
   public signinRedirect(signInRedirectOptions?: SignInRedirectOptions): void {
     const authorizeArgs: any = {};
     if (signInRedirectOptions?.location) {
-      authorizeArgs['url_state'] =  signInRedirectOptions.location;
-    }
-    if (signInRedirectOptions?.location) {
+      authorizeArgs['url_state'] = signInRedirectOptions.location;
       authorizeArgs.state = { url: signInRedirectOptions.location };
     }
     if (signInRedirectOptions?.promptRegister === true) {
@@ -146,7 +143,9 @@ export class AuthService {
     }
     this._userManager
       .signinRedirect(authorizeArgs)
-      .catch((error: any) => { });
+      .catch((error: any) => {
+        console.error('signinRedirect failed:', error);
+      });
   }
 
   public signinRedirectCallback(): Observable<User> {
@@ -154,30 +153,21 @@ export class AuthService {
       this._user = user;
       this._userSubject.next(this._user);
       return user;
-    }, (error: any) => {
-      throwError(error);
-      return null;
     }));
   }
 
-  public signinSilent(): Observable<User> {
-    return from(this._userManager.signinSilent()).pipe(map((user: any) => {
-      this._userSubject.next(user);
-      return user;
-    }));
-  }
-
-  public signinSilentCallback(): Observable<User | undefined> {
-    return from(this._userManager.signinSilentCallback()).pipe(map((user: any) => {
+  public signinSilent(): Observable<User | null> {
+    return from(this._userManager.signinSilent()).pipe(map((user: User | null) => {
       if (user) {
         this._user = user;
+        this._userSubject.next(user);
       }
-      this._userSubject.next(this._user);
       return user;
-    }, (error: any) => {
-      throwError(error);
-      return null;
     }));
+  }
+
+  public signinSilentCallback(): Observable<void> {
+    return from(this._userManager.signinSilentCallback());
   }
 
   public hasRole(roleName: string): boolean {
@@ -185,11 +175,15 @@ export class AuthService {
     if (!profile) {
       return false;
     }
-    const roleClaim = profile["role"] as string;
+    const roleClaim = profile["role"] as string | string[];
     if (roleClaim && Array.isArray(roleClaim)) {
-      const roles = Array.from(roleClaim);
-      return roles.indexOf(roleName) !== -1;
+      return roleClaim.includes(roleName);
     }
     return roleClaim === roleName;
+  }
+
+  private clearUser(): void {
+    this._user = null;
+    this._userSubject.next(null);
   }
 }

--- a/projects/ng-auth/src/lib/auth.service.ts
+++ b/projects/ng-auth/src/lib/auth.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 
 import { IdTokenClaims, SignoutResponse, User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, from, Observable, throwError } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { AUTH_SETTINGS } from './tokens';
 import { IAuthSettings, SignInRedirectOptions } from './types';
 
@@ -14,6 +14,7 @@ export class AuthService {
   private _userManager: UserManager;
   private _user: User = null as any;
   private _userSubject: BehaviorSubject<User | null> = new BehaviorSubject<User | null>(null);
+  public user$ = this._userSubject.asObservable();
 
   constructor(@Inject(AUTH_SETTINGS) authSettings: IAuthSettings) {
     this._userManager = new UserManager(authSettings);
@@ -21,22 +22,15 @@ export class AuthService {
 
     this._userManager.clearStaleState();
 
-    this._userManager.events.addUserLoaded(() => {
-      this._userManager.getUser().then((user: User | null) => {
-        if (user) {
-          this._user = user;
-          this._userSubject.next(user);
-          this._userSubject.complete();
-        } else {
-
-        }
-      });
+    this._userManager.events.addUserLoaded((user: User) => {
+      this._user = user;
+      this._userSubject.next(user);
     });
 
     this._userManager.events.addAccessTokenExpiring(() => {
       console.info('Access token expiring event occurred.');
       // No need to call this._userManager.signinSilent() since automaticSilentRenew is set to true.
-      // check your environment.ts for auth_settings 
+      // check your environment.ts for auth_settings
     });
 
     this._userManager.events.addUserSignedOut(() => {
@@ -45,21 +39,18 @@ export class AuthService {
     });
   }
 
-  public user$ = this._userSubject.asObservable();
-
   public loadUser(): Observable<User | null> {
     return from(this._userManager.getUser()).pipe(map((user: User | null) => {
       if (user) {
         this._user = user;
         this._userSubject.next(user);
-        this._userSubject.complete();
       }
       return user;
     }));
   }
 
   public isLoggedIn(): Observable<boolean> {
-    return from(this._userManager.getUser()).pipe(map<User | null, boolean>((user: User | null) => user ? true : false));
+    return this._userSubject.pipe(take(1), map<User | null, boolean>((user: User | null) => !!user && !user.expired));
   }
 
   public getUserProfile(): IdTokenClaims | undefined {
@@ -133,7 +124,6 @@ export class AuthService {
     return from(this._userManager.signoutRedirectCallback()).pipe(map((response: SignoutResponse) => {
       this._user = null as any;
       this._userSubject.next(null);
-      this._userSubject.complete();
       return response;
     }, (error: any) => {
       throwError(error);
@@ -163,7 +153,6 @@ export class AuthService {
     return from(this._userManager.signinRedirectCallback()).pipe(map((user: User) => {
       this._user = user;
       this._userSubject.next(this._user);
-      this._userSubject.complete();
       return user;
     }, (error: any) => {
       throwError(error);
@@ -174,7 +163,6 @@ export class AuthService {
   public signinSilent(): Observable<User> {
     return from(this._userManager.signinSilent()).pipe(map((user: any) => {
       this._userSubject.next(user);
-      this._userSubject.complete();
       return user;
     }));
   }
@@ -185,7 +173,6 @@ export class AuthService {
         this._user = user;
       }
       this._userSubject.next(this._user);
-      this._userSubject.complete();
       return user;
     }, (error: any) => {
       throwError(error);

--- a/projects/ng-auth/src/lib/auth.service.ts
+++ b/projects/ng-auth/src/lib/auth.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@angular/core';
 
 import { IdTokenClaims, SignoutResponse, User, UserManager } from 'oidc-client-ts';
 import { BehaviorSubject, from, Observable } from 'rxjs';
-import { map, take } from 'rxjs/operators';
+import { filter, map, switchMap, take } from 'rxjs/operators';
 import { AUTH_SETTINGS } from './tokens';
 import { IAuthSettings, SignInRedirectOptions } from './types';
 
@@ -13,8 +13,8 @@ import { IAuthSettings, SignInRedirectOptions } from './types';
 export class AuthService {
   private _userManager: UserManager;
   private _user: User | null = null;
-  private _userSubject: BehaviorSubject<User | null> = new BehaviorSubject<User | null>(null);
-  public user$ = this._userSubject.asObservable();
+  private _userSubject: BehaviorSubject<User | null | undefined> = new BehaviorSubject<User | null | undefined>(undefined);
+  public user$ = this._userSubject.asObservable().pipe(filter((user): user is User | null => user !== undefined));
 
   constructor(@Inject(AUTH_SETTINGS) authSettings: IAuthSettings) {
     this._userManager = new UserManager(authSettings);
@@ -42,16 +42,18 @@ export class AuthService {
 
   public loadUser(): Observable<User | null> {
     return from(this._userManager.getUser()).pipe(map((user: User | null) => {
-      if (user) {
-        this._user = user;
-        this._userSubject.next(user);
-      }
+      this._user = user;
+      this._userSubject.next(user);
       return user;
     }));
   }
 
   public isLoggedIn(): Observable<boolean> {
-    return this._userSubject.pipe(take(1), map<User | null, boolean>((user: User | null) => !!user && !user.expired));
+    return this._userSubject.pipe(
+      filter((user): user is User | null => user !== undefined),
+      take(1),
+      map((user) => !!user && !user.expired)
+    );
   }
 
   public getUserProfile(): IdTokenClaims | undefined {
@@ -166,8 +168,13 @@ export class AuthService {
     }));
   }
 
-  public signinSilentCallback(): Observable<void> {
-    return from(this._userManager.signinSilentCallback());
+  public signinSilentCallback(): Observable<User | null> {
+    return from(this._userManager.signinSilentCallback()).pipe(
+      switchMap(() => this._userSubject.pipe(
+        filter((user): user is User | null => user !== undefined),
+        take(1)
+      ))
+    );
   }
 
   public hasRole(roleName: string): boolean {


### PR DESCRIPTION
## The problem

The `BehaviorSubject` (`_userSubject`) was being `.complete()`-ed all over the place. Once you complete a subject, it's done, no more emissions... So `user$` would stop working after the first login, silent renew, or redirect callback. You could still check login state by reading storage directly (via `getUser()` or `getCurrentUser()`), but `user$` as a reactive stream was essentially broken.

`isLoggedIn()` was calling `this._userManager.getUser()` every time — a one-shot promise that hits storage. It didn't check token expiry either, so it could say "logged in" even with an expired token.

## What we changed

**`isLoggedIn()` now reads from memory instead of storage** — Instead of calling `getUser()` (promise that hits storage every time), it reads from `_userSubject` which already holds the current user in memory. It also checks `!user.expired` so it properly reflects token expiry. It's still a one-shot check (not reactive) thanks to `take(1)`, that means every consumer (guards, `ngOnInit` checks, redirects) expects it to emit once and complete, and we're not breaking that. If you need real-time login state, use `user$` instead.

**Fixed `addUserLoaded`** — The old handler was ignoring the `User` argument that the event already provides, then redundantly calling `getUser()` to fetch it again. Now it just uses the user directly from the event callback. Cleaner and no unnecessary async call.

**Removed all `.complete()` calls on `_userSubject`** — These were in `loadUser`, `signinRedirectCallback`, `signoutRedirectCallback`, `signinSilent`, and `signinSilentCallback`. Every one of them was permanently shutting down the subject after a single use. Now the subject stays open for the lifetime of the service, which is how a BehaviorSubject should work.

## How to use

**One-shot check** (guards, redirects, init logic) — use `isLoggedIn()`:

```ts
this.authService.isLoggedIn().subscribe(loggedIn => {
  if (!loggedIn) {
    this.authService.signinRedirect();
  }
});
```

**Real-time UI updates** (toggling buttons, showing/hiding content) — use `user$`:

```ts
// In an Angular component with signals
private user = toSignal(this.authService.user$);

$isLoggedIn = computed(() => {
  const user = this.user();
  return !!user && !user.expired;
});
```

## TLDR

`isLoggedIn()` still emits once and completes, same as before. The only difference is it's faster (no storage lookup) and more accurate (checks expiry). `user$` now actually works as a long-lived stream, which it never did before because of the `.complete()` calls.
