### PR TITLE
Remove console log in ng-config loadSettings

### DIFF
--- a/projects/ng-config/package.json
+++ b/projects/ng-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indice/ng-config",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Indice dynamic runtime configuration provider for applications",
   "repository": {
     "type": "git",

--- a/projects/ng-config/src/lib/settings-facade.service.ts
+++ b/projects/ng-config/src/lib/settings-facade.service.ts
@@ -3,6 +3,7 @@ import {
     Inject,
     inject,
     Injectable,
+    isDevMode,
     signal
 } from '@angular/core';
 import cloneDeep from 'lodash/cloneDeep';
@@ -47,6 +48,11 @@ export class SettingsFacadeService {
 
     loadSettings(): Observable<boolean> {
         return this.#settingsDataService.getAppSettings().pipe(
+            tap((settings) => {
+                if (isDevMode()) {
+                    console.log(settings);
+                }
+            }),
             map((settings) => {
                 let runtimeSettings = merge(cloneDeep(this.#environment), settings);
                 // Assign settings directly to the appSettings object
@@ -60,7 +66,6 @@ export class SettingsFacadeService {
             catchError((error) => {
                 // Log the error and provide fallback behavior
                 console.error('Failed to load settings:', error);
-
                 return of(false); // Return false to indicate failure
             })
         );

--- a/projects/ng-config/src/lib/settings-facade.service.ts
+++ b/projects/ng-config/src/lib/settings-facade.service.ts
@@ -47,7 +47,6 @@ export class SettingsFacadeService {
 
     loadSettings(): Observable<boolean> {
         return this.#settingsDataService.getAppSettings().pipe(
-            tap((settings) => console.log(settings)),
             map((settings) => {
                 let runtimeSettings = merge(cloneDeep(this.#environment), settings);
                 // Assign settings directly to the appSettings object


### PR DESCRIPTION
I suggest removing this console log since it's not necessary to fill the console with all the settings during app startup 

<img width="1569" height="693" alt="image" src="https://github.com/user-attachments/assets/3bbb3d4d-b44b-4011-ba4e-9e41d57ffcf7" />
