### PR TITLE
Set ImgUserPictureDirective to standalone

### DIFF
--- a/projects/ng-auth/package.json
+++ b/projects/ng-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indice/ng-auth",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Indice extensions for Angular v20 using oidc-client",
   "repository": {
     "type": "git",

--- a/projects/ng-auth/src/lib/directives/user-picture.directive.ts
+++ b/projects/ng-auth/src/lib/directives/user-picture.directive.ts
@@ -5,7 +5,7 @@ import { IAuthSettings } from '../types';
 
 @Directive({
     selector: 'img[userPicture]',
-    standalone: false
+    standalone: true
 })
 export class ImgUserPictureDirective implements OnInit {
     private _userId: string | undefined | null;

--- a/projects/ng-auth/src/lib/ng-auth.module.ts
+++ b/projects/ng-auth/src/lib/ng-auth.module.ts
@@ -9,8 +9,7 @@ import { TenantService } from './tenant/tenant-service';
 import { ImgUserPictureDirective } from './directives/user-picture.directive';
 
 @NgModule({
-  declarations: [ImgUserPictureDirective],
-  imports: [],
+  imports: [ImgUserPictureDirective],
   exports:[ImgUserPictureDirective]
 })
 export class IndiceAuthModule {


### PR DESCRIPTION
Change the ImgUserPictureDirective to be standalone, allowing for improved usage in Angular applications.